### PR TITLE
New estimator innov format

### DIFF
--- a/src/ecl_ekf_analysis/analysis/post_processing.py
+++ b/src/ecl_ekf_analysis/analysis/post_processing.py
@@ -42,6 +42,17 @@ def get_control_mode_flags(estimator_status: dict) -> dict:
     # 12 - true when local position data from external vision is being fused
     # 13 - true when yaw data from external vision measurements is being fused
     # 14 - true when height data from external vision measurements is being fused
+    # 15 - true when synthetic sideslip measurements are being fused
+    # 16 - true true when the mag field does not match the expected strength
+    # 17 - true true when the vehicle is operating as a fixed wing vehicle
+    # 18 - true when the magnetometer has been declared faulty and is no longer being used
+    # 19 - true true when airspeed measurements are being fused
+    # 20 - true true when protection from ground effect induced static pressure rise is active
+    # 21 - true when rng data wasn't ready for more than 10s and rng values haven't changed enough
+    # 22 - true when yaw (not ground course) data from a GPS receiver is being fused
+    # 23 - true when the in-flight mag field alignment has been completed
+    # 24 - true when velocity data from external vision measurements are being fused
+    # 25 - true when we are using a synthesized measurement for the magnetometer Z component
     control_mode['tilt_aligned'] = ((2 ** 0 & estimator_status['control_mode_flags']) > 0) * 1
     control_mode['yaw_aligned'] = ((2 ** 1 & estimator_status['control_mode_flags']) > 0) * 1
     control_mode['using_gps'] = ((2 ** 2 & estimator_status['control_mode_flags']) > 0) * 1
@@ -57,6 +68,19 @@ def get_control_mode_flags(estimator_status: dict) -> dict:
     control_mode['using_evpos'] = ((2 ** 12 & estimator_status['control_mode_flags']) > 0) * 1
     control_mode['using_evyaw'] = ((2 ** 13 & estimator_status['control_mode_flags']) > 0) * 1
     control_mode['using_evhgt'] = ((2 ** 14 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['fuse_beta'] = ((2 ** 15 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['mag_field_disturbed'] = (
+        (2 ** 16 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['fixed_wing'] = ((2 ** 17 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['mag_fault'] = ((2 ** 18 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['fuse_aspd'] = ((2 ** 19 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['gnd_effect'] = ((2 ** 20 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['rng_stuck'] = ((2 ** 21 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['gps_yaw'] = ((2 ** 22 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['mag_aligned_in_flight'] = (
+        (2 ** 23 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['ev_vel'] = ((2 ** 24 & estimator_status['control_mode_flags']) > 0) * 1
+    control_mode['synthetic_mag_z'] = ((2 ** 25 & estimator_status['control_mode_flags']) > 0) * 1
     return control_mode
 
 

--- a/src/ecl_ekf_analysis/log_processing/data_version_handler.py
+++ b/src/ecl_ekf_analysis/log_processing/data_version_handler.py
@@ -52,19 +52,22 @@ def get_field_name_from_message_and_descriptor(message: str, field_descriptor: s
     return the actual field name for a field descriptor
     e.g. message: ekf2_innovations; field_descriptor: magnetometer_innovations -> mag_innov
     :param ulog:
-    :return: str
+    :return: str (if field not found, None will be returned)
     """
     msg_lookUp_dict = {
         'ekf2_innovations' :
             {
-                'magnetometer_innovation' : 'mag_innov',
+                'vel_pos_innovation' : 'vel_pos_innov',
+                'aux_hvel_innovation' : 'aux_vel_innov',
+                'mag_field_innovation' : 'mag_innov',
                 'heading_innovation' : 'heading_innov',
                 'airspeed_innovation' : 'airspeed_innov',
                 'sideslip_innovation' : 'beta_innov',
                 'flow_innovation' : 'flow_innov',
                 'hagl_innovation' : 'hagl_innov',
                 'drag_innovation' : 'drag_innov',
-                'magnetometer_innovation_variance' : 'mag_innov_var',
+                'vel_pos_innovation_variance' : 'vel_pos_innov_var',
+                'mag_field_innovation_variance' : 'mag_innov_var',
                 'heading_innovation_variance' : 'heading_innov_var',
                 'airspeed_innovation_variance' : 'airspeed_innov_var',
                 'sideslip_innovation_variance' : 'beta_innov_var',
@@ -74,7 +77,23 @@ def get_field_name_from_message_and_descriptor(message: str, field_descriptor: s
             },
         'estimator_innovations' :
             {
-                'magnetometer_innovation' : 'mag',
+                'gps_hvel_innovation' : 'gps_hvel',
+                'gps_vvel_innovation' : 'gps_vvel',
+                'gps_hpos_innovation' : 'gps_hpos',
+                'gps_vpos_innovation' : 'gps_vpos',
+                'vision_hvel_innovation' : 'ev_hvel',
+                'vision_vvel_innovation' : 'ev_vvel',
+                'vision_hpos_innovation' : 'ev_hpos',
+                'vision_vpos_innovation' : 'ev_vpos',
+                'fake_hvel_innovation' : 'fake_hvel',
+                'fake_vvel_innovation' : 'fake_vvel',
+                'fake_hpos_innovation' : 'fake_hpos',
+                'fake_vpos_innovation' : 'fake_vpos',
+                'rng_vpos_innovation' : 'rng_vpos',
+                'baro_vpos_innovation' : 'baro_vpos',
+                'aux_hvel_innovation' : 'aux_hvel',
+                'aux_vvel_innovation' : 'aux_vvel',
+                'mag_field_innovation' : 'mag_field',
                 'heading_innovation' : 'heading',
                 'airspeed_innovation' : 'airspeed',
                 'sideslip_innovation' : 'beta',
@@ -84,7 +103,23 @@ def get_field_name_from_message_and_descriptor(message: str, field_descriptor: s
             },
         'estimator_innovation_variances' :
             {
-                'magnetometer_innovation_variance' : 'mag',
+                'gps_hvel_innovation_variance' : 'gps_hvel',
+                'gps_vvel_innovation_variance' : 'gps_vvel',
+                'gps_hpos_innovation_variance' : 'gps_hpos',
+                'gps_vpos_innovation_variance' : 'gps_vpos',
+                'vision_hvel_innovation_variance' : 'ev_hvel',
+                'vision_vvel_innovation_variance' : 'ev_vvel',
+                'vision_hpos_innovation_variance' : 'ev_hpos',
+                'vision_vpos_innovation_variance' : 'ev_vpos',
+                'fake_hvel_innovation_variance' : 'fake_hvel',
+                'fake_vvel_innovation_variance' : 'fake_vvel',
+                'fake_hpos_innovation_variance' : 'fake_hpos',
+                'fake_vpos_innovation_variance' : 'fake_vpos',
+                'rng_vpos_innovation_variance' : 'rng_vpos',
+                'baro_vpos_innovation_variance' : 'baro_vpos',
+                'aux_hvel_innovation_variance' : 'aux_hvel',
+                'aux_vvel_innovation_variance' : 'aux_vvel',
+                'mag_field_innovation_variance' : 'mag_field',
                 'heading_innovation_variance' : 'heading',
                 'airspeed_innovation_variance' : 'airspeed',
                 'sideslip_innovation_variance' : 'beta',
@@ -96,7 +131,29 @@ def get_field_name_from_message_and_descriptor(message: str, field_descriptor: s
 
     field = msg_lookUp_dict[message].get(field_descriptor, None)
 
-    if field is None:
-        raise PreconditionError("Could not find field in lookup table")
-
     return field
+
+
+def check_if_field_name_exists_in_message(ulog: ULog, message_name: str, field_name: str) -> bool:
+    """
+        Check if a field is part of a message in a certain log
+    """
+    if field_name is None:
+        return False
+
+    msg_data = ulog.get_dataset(message_name).data
+    field_name_list = dict.keys(msg_data)
+
+    for elem in field_name_list:
+        if field_name == field_name_wo_brackets(elem):
+            return True
+
+    return False
+
+def field_name_wo_brackets(field_name: str) -> str:
+    """
+        Field names in a ulog message can end with [*]. This function removes the [*] at the end
+    """
+    if field_name.endswith(']'):
+        return field_name[:-3]
+    return field_name

--- a/src/ecl_ekf_analysis/log_processing/data_version_handler.py
+++ b/src/ecl_ekf_analysis/log_processing/data_version_handler.py
@@ -1,0 +1,102 @@
+#! /usr/bin/env python3
+"""
+function collection for handling different versions of log files
+"""
+from pyulog import ULog
+from ecl_ekf_analysis.log_processing.custom_exceptions import PreconditionError
+
+def get_output_tracking_error_message(ulog: ULog) -> str:
+    """
+    return the name of the message containing the output_tracking_error
+    :param ulog:
+    :return: str
+    """
+    for elem in  ulog.data_list:
+        if elem.name == "ekf2_innovations":
+            return "ekf2_innovations"
+        if elem.name == "estimator_innovations":
+            return "estimator_status"
+
+    raise PreconditionError("Could not detect the message containing the output tracking error")
+
+def get_innovation_message(ulog: ULog) -> str:
+    """
+    return the name of the innovation message (old: ekf2_innovations; new: estimator_innovations)
+    :param ulog:
+    :return: str
+    """
+    for elem in  ulog.data_list:
+        if elem.name == "ekf2_innovations":
+            return "ekf2_innovations"
+        if elem.name == "estimator_innovations":
+            return "estimator_innovations"
+
+    raise PreconditionError("Could not detect any known innovation message")
+
+def get_innovation_variance_message(ulog: ULog) -> str:
+    """
+    return the name of the innovation variance message
+    :param ulog:
+    :return: str
+    """
+    for elem in  ulog.data_list:
+        if elem.name == "ekf2_innovations":
+            return "ekf2_innovations"
+        if elem.name == "estimator_innovations":
+            return "estimator_innovation_variances"
+
+    raise PreconditionError("Could not detect any known innovation message")
+
+def get_field_name_from_message_and_descriptor(message: str, field_descriptor: str) -> str:
+    """
+    return the actual field name for a field descriptor
+    e.g. message: ekf2_innovations; field_descriptor: magnetometer_innovations -> mag_innov
+    :param ulog:
+    :return: str
+    """
+    msg_lookUp_dict = {
+        'ekf2_innovations' :
+            {
+                'magnetometer_innovation' : 'mag_innov',
+                'heading_innovation' : 'heading_innov',
+                'airspeed_innovation' : 'airspeed_innov',
+                'sideslip_innovation' : 'beta_innov',
+                'flow_innovation' : 'flow_innov',
+                'hagl_innovation' : 'hagl_innov',
+                'drag_innovation' : 'drag_innov',
+                'magnetometer_innovation_variance' : 'mag_innov_var',
+                'heading_innovation_variance' : 'heading_innov_var',
+                'airspeed_innovation_variance' : 'airspeed_innov_var',
+                'sideslip_innovation_variance' : 'beta_innov_var',
+                'flow_innovation_variance' : 'flow_innov_var',
+                'hagl_innovation_variance' : 'hagl_innov_var',
+                'drag_innovation_variance' : 'drag_innov_var'
+            },
+        'estimator_innovations' :
+            {
+                'magnetometer_innovation' : 'mag',
+                'heading_innovation' : 'heading',
+                'airspeed_innovation' : 'airspeed',
+                'sideslip_innovation' : 'beta',
+                'flow_innovation' : 'flow',
+                'hagl_innovation' : 'hagl',
+                'drag_innovation' : 'drag',
+            },
+        'estimator_innovation_variances' :
+            {
+                'magnetometer_innovation_variance' : 'mag',
+                'heading_innovation_variance' : 'heading',
+                'airspeed_innovation_variance' : 'airspeed',
+                'sideslip_innovation_variance' : 'beta',
+                'flow_innovation_variance' : 'flow',
+                'hagl_innovation_variance' : 'hagl',
+                'drag_innovation_variance' : 'drag'
+            }
+    }
+
+    field = msg_lookUp_dict[message].get(field_descriptor, None)
+
+    if field is None:
+        raise PreconditionError("Could not find field in lookup table")
+
+    return field

--- a/tests/test_data_version_handler.py
+++ b/tests/test_data_version_handler.py
@@ -57,17 +57,123 @@ def test_get_innovation_variance_message(testing_args):
     assert dvh.get_innovation_variance_message(
         log_est_format_version_2) == "estimator_innovation_variances"
 
-def test_get_field_name_from_message_and_descriptor():
-    """
-     Test if the return field name for different messages is correct
-    """
 
-    assert dvh.get_field_name_from_message_and_descriptor(
-        'ekf2_innovations', 'magnetometer_innovation') == 'mag_innov'
-    assert dvh.get_field_name_from_message_and_descriptor(
-        'ekf2_innovations', 'magnetometer_innovation_variance') == 'mag_innov_var'
+test_data = [
+    ("est_format_version_1", 'innovation', 'vel_pos_innovation', True),
+    ("est_format_version_1", 'innovation', 'gps_vvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'gps_hvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'gps_hpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'gps_vpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'vision_hvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'vision_vvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'vision_hpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'vision_vpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'fake_hvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'fake_vvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'fake_hpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'fake_vpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'rng_vpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'baro_vpos_innovation', False),
+    ("est_format_version_1", 'innovation', 'aux_hvel_innovation', True),
+    ("est_format_version_1", 'innovation', 'aux_vvel_innovation', False),
+    ("est_format_version_1", 'innovation', 'mag_field_innovation', True),
+    ("est_format_version_1", 'innovation', 'heading_innovation', True),
+    ("est_format_version_1", 'innovation', 'airspeed_innovation', True),
+    ("est_format_version_1", 'innovation', 'sideslip_innovation', True),
+    ("est_format_version_1", 'innovation', 'flow_innovation', True),
+    ("est_format_version_1", 'innovation', 'hagl_innovation', True),
+    ("est_format_version_1", 'innovation', 'drag_innovation', True),
+    ("est_format_version_1", 'innovation_variance', 'vel_pos_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'gps_vvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'gps_hvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'gps_hpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'gps_vpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'vision_hvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'vision_vvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'vision_hpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'vision_vpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'fake_hvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'fake_vvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'fake_hpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'fake_vpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'rng_vpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'baro_vpos_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'aux_hvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'aux_vvel_innovation_variance', False),
+    ("est_format_version_1", 'innovation_variance', 'mag_field_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'heading_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'airspeed_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'sideslip_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'flow_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'hagl_innovation_variance', True),
+    ("est_format_version_1", 'innovation_variance', 'drag_innovation_variance', True),
+    ("est_format_version_2", 'innovation', 'vel_pos_innovation', False),
+    ("est_format_version_2", 'innovation', 'gps_vvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'gps_hvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'gps_hpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'gps_vpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'vision_hvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'vision_vvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'vision_hpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'vision_vpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'fake_hvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'fake_vvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'fake_hpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'fake_vpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'rng_vpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'baro_vpos_innovation', True),
+    ("est_format_version_2", 'innovation', 'aux_hvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'aux_vvel_innovation', True),
+    ("est_format_version_2", 'innovation', 'mag_field_innovation', True),
+    ("est_format_version_2", 'innovation', 'heading_innovation', True),
+    ("est_format_version_2", 'innovation', 'airspeed_innovation', True),
+    ("est_format_version_2", 'innovation', 'sideslip_innovation', True),
+    ("est_format_version_2", 'innovation', 'flow_innovation', True),
+    ("est_format_version_2", 'innovation', 'hagl_innovation', True),
+    ("est_format_version_2", 'innovation', 'drag_innovation', True),
+    ("est_format_version_2", 'innovation_variance', 'vel_pos_innovation_variance', False),
+    ("est_format_version_2", 'innovation_variance', 'gps_vvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'gps_hvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'gps_hpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'gps_vpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'vision_hvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'vision_vvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'vision_hpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'vision_vpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'fake_hvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'fake_vvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'fake_hpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'fake_vpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'rng_vpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'baro_vpos_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'aux_hvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'aux_vvel_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'mag_field_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'heading_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'airspeed_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'sideslip_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'flow_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'hagl_innovation_variance', True),
+    ("est_format_version_2", 'innovation_variance', 'drag_innovation_variance', True),
+]
 
-    assert dvh.get_field_name_from_message_and_descriptor(
-        'estimator_innovations', 'magnetometer_innovation') == 'mag'
-    assert dvh.get_field_name_from_message_and_descriptor(
-        'estimator_innovation_variances', 'magnetometer_innovation_variance') == 'mag'
+@pytest.mark.parametrize(
+    "est_format_version,message_descriptor,field_name_req,should_exist", test_data)
+
+def test_get_field_name_from_message_and_descriptor(
+        testing_args, est_format_version, message_descriptor, field_name_req, should_exist):
+    """
+        Test logs of different verison for the existence/inexistence
+        of innovation and innovation_variance fields
+    """
+    log = testing_args[est_format_version]
+
+    message_name = ""
+    if message_descriptor == "innovation":
+        message_name = dvh.get_innovation_message(log)
+    if message_descriptor == "innovation_variance":
+        message_name = dvh.get_innovation_variance_message(log)
+
+    field_name = dvh.get_field_name_from_message_and_descriptor(message_name, field_name_req)
+
+    assert dvh.check_if_field_name_exists_in_message(log, message_name, field_name) == should_exist

--- a/tests/test_data_version_handler.py
+++ b/tests/test_data_version_handler.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python3
+"""
+Testing the data version handler.
+"""
+import os
+import pytest
+from pyulog import ULog
+
+import ecl_ekf_analysis.log_processing.data_version_handler as dvh
+
+@pytest.fixture(scope="module")
+def testing_args():
+    """
+    arguments for testing.
+    :return: test arguments
+    """
+    flight_logs_path = os.path.join(os.path.dirname(__file__), 'flight_logs')
+    log_est_format_v1 = ULog(os.path.join(flight_logs_path, 'short_f450_log.ulg'))
+    log_est_format_v2 = ULog(os.path.join(flight_logs_path, 'estimator_innovations.ulg'))
+
+    return {'est_format_version_1': log_est_format_v1,
+            'est_format_version_2': log_est_format_v2}
+
+def test_get_output_tracking_error_message(testing_args):
+    """
+        Test if the right message name will be returned for different log file versions
+    """
+
+    log_est_format_version_1 = testing_args['est_format_version_1']
+    log_est_format_version_2 = testing_args['est_format_version_2']
+
+    assert dvh.get_output_tracking_error_message(log_est_format_version_1) == "ekf2_innovations"
+    assert dvh.get_output_tracking_error_message(log_est_format_version_2) == "estimator_status"
+
+
+def test_get_innovation_message(testing_args):
+    """
+        Test if the right message name will be returned for different log file versions
+    """
+
+    log_est_format_version_1 = testing_args['est_format_version_1']
+    log_est_format_version_2 = testing_args['est_format_version_2']
+
+    assert dvh.get_innovation_message(log_est_format_version_1) == "ekf2_innovations"
+    assert dvh.get_innovation_message(log_est_format_version_2) == "estimator_innovations"
+
+def test_get_innovation_variance_message(testing_args):
+    """
+        Test if the right message name will be returned for different log file versions
+    """
+
+    log_est_format_version_1 = testing_args['est_format_version_1']
+    log_est_format_version_2 = testing_args['est_format_version_2']
+
+    assert dvh.get_innovation_variance_message(
+        log_est_format_version_1) == "ekf2_innovations"
+    assert dvh.get_innovation_variance_message(
+        log_est_format_version_2) == "estimator_innovation_variances"
+
+def test_get_field_name_from_message_and_descriptor():
+    """
+     Test if the return field name for different messages is correct
+    """
+
+    assert dvh.get_field_name_from_message_and_descriptor(
+        'ekf2_innovations', 'magnetometer_innovation') == 'mag_innov'
+    assert dvh.get_field_name_from_message_and_descriptor(
+        'ekf2_innovations', 'magnetometer_innovation_variance') == 'mag_innov_var'
+
+    assert dvh.get_field_name_from_message_and_descriptor(
+        'estimator_innovations', 'magnetometer_innovation') == 'mag'
+    assert dvh.get_field_name_from_message_and_descriptor(
+        'estimator_innovation_variances', 'magnetometer_innovation_variance') == 'mag'


### PR DESCRIPTION
This [Firmware PR](https://github.com/PX4/Firmware/pull/13127) is changing the logged estimator innovation message. 
This PR adds basic functions that can check which message and field contain the innovation and the innovation variance. This is tested with a log that contains data in the new format. For proper ekf_analysis with the new message format a new log that is more suited for general performance should be recorded and added. 