### PR TITLE
remove hagl amber failure, re-tune hagl innovation fail ratio

### DIFF
--- a/src/ecl_ekf_analysis/config/thresholds.ini
+++ b/src/ecl_ekf_analysis/config/thresholds.ini
@@ -35,8 +35,7 @@ baro_height_amber_warning_pct = 5.0
 range_sensor_height_amber_failure_pct = 50.0
 range_sensor_height_amber_warning_pct = 5.0
 
-height_above_ground_innovation_failure_pct = 20.0
-height_above_ground_amber_failure_pct = 50.0
+height_above_ground_innovation_failure_pct = 95.0
 height_above_ground_amber_warning_pct = 5.0
 
 airspeed_innovation_failure_pct = 0.0


### PR DESCRIPTION
## summary
re-tune the height above ground innovation check.

## details
* remove amber failure pct threshold: too many false positives -> only output warnings for bad height above ground innovations
* increase fail ratio threshold to 95%: too many false positives at 20% -> 95% of test ratio > 1 is very unlikely to be a false positive