### PR TITLE
[APX4-2308] Increase mag innovation warning threshold

### DIFF
--- a/src/ecl_ekf_analysis/config/thresholds.ini
+++ b/src/ecl_ekf_analysis/config/thresholds.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 magnetometer_amber_failure_pct = 50.0
-magnetometer_amber_warning_pct = 0.5
+magnetometer_amber_warning_pct = 15.0
 magnetometer_short_rolling_innovation_failure_pct = 50.0
 magnetometer_long_rolling_innovation_warning_pct = 10.0
 


### PR DESCRIPTION
https://auterion.atlassian.net/browse/APX4-2308

This was triggering warning on a single test ratio > 0.5 on short
flights.
0.5% is way too strict and the warning pct should be higher than the long rolling innovation warning.