### PR TITLE
Numerical error checks: ignore unrelated flags

### DIFF
--- a/src/ecl_ekf_analysis/checks/numerical_analysis.py
+++ b/src/ecl_ekf_analysis/checks/numerical_analysis.py
@@ -47,9 +47,10 @@ class NumericalCheck(Check):
         "fs_bad_pos_n",
         "fs_bad_pos_e",
         "fs_bad_pos_d",
-        "fs_bad_acc_bias",
-        "fs_bad_acc_vertical",
-        "fs_bad_acc_clipping",
+        # Do not consider flags that are not related to numerical issues
+        # "fs_bad_acc_bias",
+        # "fs_bad_acc_vertical",
+        # "fs_bad_acc_clipping",
         ]
 
         filter_fault_flag.value = 0.0

--- a/src/ecl_ekf_analysis/checks/numerical_analysis.py
+++ b/src/ecl_ekf_analysis/checks/numerical_analysis.py
@@ -26,10 +26,37 @@ class NumericalCheck(Check):
         """
         :return:
         """
-        estimator_status_data = self.ulog.get_dataset('estimator_status').data
+        estimator_status_data = self.ulog.get_dataset('estimator_status_flags').data
 
         filter_fault_flag = self.add_statistic(
             CheckStatisticType.FILTER_FAULT_FLAG)
-        filter_fault_flag.value = float(
-            np.amax(estimator_status_data['filter_fault_flags']))
+
+        flags = [
+        "fs_bad_mag_x",
+        "fs_bad_mag_y",
+        "fs_bad_mag_z",
+        "fs_bad_hdg",
+        "fs_bad_mag_decl",
+        "fs_bad_airspeed",
+        "fs_bad_sideslip",
+        "fs_bad_optflow_x",
+        "fs_bad_optflow_y",
+        "fs_bad_vel_n",
+        "fs_bad_vel_e",
+        "fs_bad_vel_d",
+        "fs_bad_pos_n",
+        "fs_bad_pos_e",
+        "fs_bad_pos_d",
+        "fs_bad_acc_bias",
+        "fs_bad_acc_vertical",
+        "fs_bad_acc_clipping",
+        ]
+
+        filter_fault_flag.value = 0.0
+
+        for flag in flags:
+            if np.any(estimator_status_data[flag]):
+                filter_fault_flag.value = 1.0
+                break
+
         filter_fault_flag.thresholds.failure = thresholds.ecl_filter_fault_flag_failure()


### PR DESCRIPTION
Use explicit fields instead of "old" bitmask to avoid bugs due to future outdated bitmask definition

fs_bad_acc_bias, fs_bad_acc_vertical and fs_bad_acc_clipping are not related to numerical issuse. The check shouldn't include those flags