### PR TITLE
SUITE-3666 Update EKF bias source, update thresholds

### DIFF
--- a/ops/compose/Dockerfile
+++ b/ops/compose/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.6
+FROM --platform=linux/amd64 python:3.6
+
 
 COPY requirements.txt dev-requirements.txt /app/
 COPY . /app/libs/ecl-ekf-analysis

--- a/src/ecl_ekf_analysis/config/thresholds.ini
+++ b/src/ecl_ekf_analysis/config/thresholds.ini
@@ -67,8 +67,8 @@ imu_high_freq_delta_velocity_warning_rolling_avg = 0.2
 imu_observed_angle_error_warning_avg = 8.0E-3
 imu_observed_velocity_error_warning_avg = 0.05
 imu_observed_position_error_warning_avg = 0.15
-imu_delta_angle_bias_warning_avg = 4.4E-4
-imu_delta_velocity_bias_warning_avg = 4.8E-3
+imu_delta_angle_bias_warning_avg = 4.4E-2
+imu_delta_velocity_bias_warning_avg = 0.48
 
 # Disable filter_fault_flag_failure by setting > 1
 filter_fault_flag_failure = 10.0


### PR DESCRIPTION
Update uORB topic to collect accel and gyro biases when computing the checks for biases. Values were inflated by 100 compared to the previous source, so thresholds were updated to reflect that.